### PR TITLE
Feature/#43 async image

### DIFF
--- a/MoRI/MoRI.xcodeproj/project.pbxproj
+++ b/MoRI/MoRI.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		C18294692A6630090027577F /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18294682A6630090027577F /* MainView.swift */; };
 		C182946C2A66B8750027577F /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C182946B2A66B8750027577F /* View+Extension.swift */; };
 		C182946E2A66C8B90027577F /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C182946D2A66C8B90027577F /* Color+Extension.swift */; };
+		C1982A912A6FA64000DD9E02 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1982A902A6FA64000DD9E02 /* AsyncImageView.swift */; };
 		D1A8D1722A6E7BEC0086BF9B /* CompleteCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8D1712A6E7BEC0086BF9B /* CompleteCardView.swift */; };
 		D1A8D1742A6E7BFF0086BF9B /* CompleteCardTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8D1732A6E7BFF0086BF9B /* CompleteCardTop.swift */; };
 		D1A8D1762A6E7C130086BF9B /* CompleteCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A8D1752A6E7C130086BF9B /* CompleteCardViewModel.swift */; };
@@ -74,6 +75,7 @@
 		C18294682A6630090027577F /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		C182946B2A66B8750027577F /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		C182946D2A66C8B90027577F /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
+		C1982A902A6FA64000DD9E02 /* AsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AsyncImageView.swift; path = MoRI/View/AsyncImageView.swift; sourceTree = SOURCE_ROOT; };
 		D1A8D1712A6E7BEC0086BF9B /* CompleteCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCardView.swift; sourceTree = "<group>"; };
 		D1A8D1732A6E7BFF0086BF9B /* CompleteCardTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCardTop.swift; sourceTree = "<group>"; };
 		D1A8D1752A6E7C130086BF9B /* CompleteCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteCardViewModel.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				C18294662A6627C00027577F /* SelectLyricsView.swift */,
 				C18294682A6630090027577F /* MainView.swift */,
 				8E9CB8B72A68D7DB0088D736 /* ArchiveCardChipView.swift */,
+				C1982A902A6FA64000DD9E02 /* AsyncImageView.swift */,
 			);
 			path = VIew;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				6CC611C72A6570B500B171FD /* Persistence.swift in Sources */,
 				6CC611C02A6570B300B171FD /* ContentView.swift in Sources */,
 				C18294652A6627840027577F /* SearchMusicViewModel.swift in Sources */,
+				C1982A912A6FA64000DD9E02 /* AsyncImageView.swift in Sources */,
 				6CDE92C62A6CA63200A569BD /* CardDetailTop.swift in Sources */,
 				6CDE92C32A6CA4CF00A569BD /* CardDetailViewModel.swift in Sources */,
 				D1A8D1742A6E7BFF0086BF9B /* CompleteCardTop.swift in Sources */,

--- a/MoRI/MoRI/VIew/AsyncImageView.swift
+++ b/MoRI/MoRI/VIew/AsyncImageView.swift
@@ -1,0 +1,27 @@
+//
+//  AsyncImageView.swift
+//  MoRI
+//
+//  Created by GYURI PARK on 2023/07/25.
+//
+
+import SwiftUI
+
+struct AsyncImageView: View {
+    let url: URL
+
+    var body: some View {
+        AsyncImage(url: url) { image in
+            image
+                .resizable()
+                .scaledToFit()
+                .frame(width: 56, height: 56)
+                .padding(.leading, 35)
+        } placeholder: {
+            Image(systemName: "music.note")
+                .resizable()
+                .frame(width: 56, height: 56)
+                .cornerRadius(4.8)
+        }
+    }
+}

--- a/MoRI/MoRI/VIew/SearchMusicView.swift
+++ b/MoRI/MoRI/VIew/SearchMusicView.swift
@@ -12,7 +12,6 @@ struct SearchMusicView: View {
     @ObservedObject var lyricsViewModel = SelectLyricsViewModel()
     @State var songData = SelectedSong(name: "", artist: "")
     
-    
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {

--- a/MoRI/MoRI/VIew/SelectLyricsView.swift
+++ b/MoRI/MoRI/VIew/SelectLyricsView.swift
@@ -11,29 +11,16 @@ struct SelectLyricsView: View {
     @ObservedObject var musicViewModel: SearchMusicViewModel
     @ObservedObject var lyricsViewModel: SelectLyricsViewModel
     @Binding var songData: SelectedSong
-    
 
     @State private var selectedTexts: [String] = Array(repeating: "", count: 4)
-
-//    @State private var selectedTexts: [String] = []
     @State private var startSelectionIndex: Int?
     
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        
         VStack{
             HStack(spacing: 11){
-                
-                AsyncImage(url: songData.imageUrl) { image in
-                            image
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 56, height: 56)
-                                .padding(.leading, 35)
-                        } placeholder: {
-                        }
-                
+                AsyncImageView(url: songData.imageUrl!)
                 VStack(alignment: .leading){
                     Text(songData.name)
                         .foregroundColor(Color(hex: 0x111111))
@@ -44,7 +31,6 @@ struct SelectLyricsView: View {
                 }
                 Spacer()
             }
-            
             
             ScrollView {
                 VStack(){
@@ -98,18 +84,22 @@ struct SelectLyricsView: View {
             .padding(.top, 33)
         }
         .background(
-            Image(uiImage: UIImage(data: try! Data(contentsOf: songData.imageUrl!))!)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .ignoresSafeArea()
-                .blur(radius: 20)
+            AsyncImage(url: songData.imageUrl) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .ignoresSafeArea()
+                    .blur(radius: 20)
+            } placeholder : {
+                Image(systemName: "music.note")
+                    .resizable()
+                    .frame(width: 56, height: 56)
+                    .cornerRadius(4.8)
+            }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: backButton)
-        
-        
-        
     }
     
     var selectedLyrics: String {
@@ -127,3 +117,4 @@ struct SelectLyricsView: View {
         }
     }
 }
+


### PR DESCRIPTION
## 👀 개요
- #43 

## 👍 작업 내용
- SelectLyricsView 배경에 들어가는 앨범아트 이미지를 비동기적으로 처리합니다.

## 🤔 고민한 점  (Optional)
### 1. imageURL 비동기적 처리
- 문제 상황
 SelectLyricsView에 접근할 때마다 뜨는 `Synchronous URL loading of https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/c0/13/22/c01322df-40be-a2c8-56e8-f5be1d3471fa/Yerin_Baek.jpg/1000x1000bb.jpg should not occur on this application's main thread as it may lead to UI unresponsiveness. Please switch to an asynchronous networking API such as URLSession.` 오류 해결하기
- 해결 방법
AsyncImageView를 따로 구현해서 imgaeURL을 처리합니다.

- 의문점
songData.imageUrl 자체가 nil일 경우도 처리해줘야 함

## 📱 구현한 UI

