### PR TITLE
Refactor/#124 scale card frame

### DIFF
--- a/MoRI/MoRI.xcodeproj/project.pbxproj
+++ b/MoRI/MoRI.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		8E0F94FC2A6D680E0053FCAA /* CardDetailArt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0F94FB2A6D680E0053FCAA /* CardDetailArt.swift */; };
 		8E9CB8B82A68D7DB0088D736 /* ArchiveCardChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9CB8B72A68D7DB0088D736 /* ArchiveCardChipView.swift */; };
 		C1217EC22A76B618005C4868 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1217EC12A76B618005C4868 /* SplashView.swift */; };
+		C1423D452A9ED98B00905B9C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1423D442A9ED98B00905B9C /* Constants.swift */; };
 		C1749AFF2A677D6900C089DB /* SelectLyricsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1749AFE2A677D6900C089DB /* SelectLyricsViewModel.swift */; };
 		C1749B072A6A11D700C089DB /* FontsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1749B062A6A11D700C089DB /* FontsManager.swift */; };
 		C1749B0B2A6A11FA00C089DB /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = C1749B082A6A11FA00C089DB /* Pretendard-SemiBold.otf */; };
@@ -79,6 +80,7 @@
 		9E9F74FBA25F41C615921B03 /* Pods-MoRI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MoRI.release.xcconfig"; path = "Target Support Files/Pods-MoRI/Pods-MoRI.release.xcconfig"; sourceTree = "<group>"; };
 		BC8BA210E0E2A857310AE2F4 /* Pods_MoRI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoRI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1217EC12A76B618005C4868 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		C1423D442A9ED98B00905B9C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C1749AFE2A677D6900C089DB /* SelectLyricsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLyricsViewModel.swift; sourceTree = "<group>"; };
 		C1749B022A68FFD900C089DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C1749B062A6A11D700C089DB /* FontsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontsManager.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				6C8916A22A6FEE5E001350E0 /* NavigationUtils.swift */,
 				6C8916AB2A736605001350E0 /* ExtractImage.swift */,
 				D1A8D1772A77A0E00086BF9B /* ShareInstagram.swift */,
+				C1423D442A9ED98B00905B9C /* Constants.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 				D1A8D1762A6E7C130086BF9B /* CompleteCardViewModel.swift in Sources */,
 				6CDE92BB2A6BF27000A569BD /* EditCardViewModel.swift in Sources */,
 				8E9CB8B82A68D7DB0088D736 /* ArchiveCardChipView.swift in Sources */,
+				C1423D452A9ED98B00905B9C /* Constants.swift in Sources */,
 				C18294612A6627530027577F /* SearchMusicView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -566,7 +570,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MoRI/Preview Content\"";
-				DEVELOPMENT_TEAM = 95KH8LTQV6;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MoRI/Info.plist;
@@ -598,7 +602,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MoRI/Preview Content\"";
-				DEVELOPMENT_TEAM = 95KH8LTQV6;
+				DEVELOPMENT_TEAM = XF4GNZL7MP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MoRI/Info.plist;

--- a/MoRI/MoRI/Utils/Constants.swift
+++ b/MoRI/MoRI/Utils/Constants.swift
@@ -1,0 +1,27 @@
+//
+//  Constants.swift
+//  MoRI
+//
+//  Created by GYURI PARK on 2023/08/30.
+//
+
+import Foundation
+import SwiftUI
+
+//struct Constants {
+//    static var logoSize: CGSize {
+//        switch UIScreen.main.bounds.size {
+//        case CGSize(width: 430, height: 932):
+//            return CGSize(width: 364, height: 382)
+//        case CGSize(width: 428, height: 926): // 12 Pro Max
+//            return CGSize(width: 364, height: 382)
+//        case CGSize(width: 320, height: 568): // SE
+//            return CGSize(width: 292, height: 311)
+//        default:
+//            return CGSize(width: 199.36, height: 69.93)
+//        }
+//    }
+//}
+
+
+//.frame(width: 199.36, height: 69.93)

--- a/MoRI/MoRI/View/ArchiveCardChipView.swift
+++ b/MoRI/MoRI/View/ArchiveCardChipView.swift
@@ -39,6 +39,9 @@ struct ArchiveCardChipView: View {
     @State private var isDeleteCard = false // 카드 삭제버튼 선택 여부
     @State private var isShareSheetShowing = false  // 카드 공유버튼 선택 여부
     
+    private let screenWidth = UIScreen.main.bounds.size.width
+    private let screenHeight = UIScreen.main.bounds.size.height
+    
     var body: some View {
         var standardAngle: Double = items.count > 0 ? Double(360 / items.count) : 0  // 카드 1장 당의 단위각도
         let zIndexPreset = items.count > 0 ? (1...items.count).map { value in Double(value) / Double(1) }.reversed() : []   // 중첩 레벨
@@ -164,6 +167,7 @@ struct ArchiveCardChipView: View {
                     .shadow(radius: 5, x: 8, y: -4)
                     .gesture(dragGesture)
                 }
+                .scaleEffect(screenWidth/393)
                 .frame(width: 350, height: ((screenHeight - 82.79) / 761.21) * 570, alignment: .center)
                 .background(backgroundArchive)
                 .cornerRadius(20)

--- a/MoRI/MoRI/View/CompleteCard/CompleteCardView.swift
+++ b/MoRI/MoRI/View/CompleteCard/CompleteCardView.swift
@@ -22,7 +22,8 @@ struct CompleteCardView: View {
     
     @Binding var pureData: PureSong
     
-    
+    private let screenWidth = UIScreen.main.bounds.size.width
+
     var body: some View {
         
         VStack(spacing: 0){
@@ -43,6 +44,7 @@ struct CompleteCardView: View {
                     .frame(width: 314, alignment: .leading)
                     .foregroundColor(viewModel.lyricsColor)
                     .font(.custom(FontsManager.Pretendard.medium, size: 17))
+                    .lineLimit(4)
                     .lineSpacing(15)
             }
             .compositingGroup()
@@ -97,6 +99,7 @@ struct CompleteCardView: View {
             
             
         }
+        .scaleEffect(screenWidth/393)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Image(uiImage:viewModel.card.albumArtUIImage).resizable().ignoresSafeArea().scaledToFill().blur(radius: 20))
         .navigationBarBackButtonHidden(true)

--- a/MoRI/MoRI/View/EditCard/EditCardView.swift
+++ b/MoRI/MoRI/View/EditCard/EditCardView.swift
@@ -12,6 +12,7 @@ struct EditCardView: View {
     @Environment(\.dismiss) private var dismiss
     @Binding var pureData: PureSong
     
+    let screenWidth = UIScreen.main.bounds.size.width
     
     var backButton: some View {
         Button(action: {
@@ -57,6 +58,7 @@ struct EditCardView: View {
             }
             .padding(.top, 34)
         }
+        .scaleEffect(screenWidth/393.0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Image(uiImage:viewModel.card.albumArtUIImage)
             .resizable()

--- a/MoRI/MoRI/View/OnBoardingView.swift
+++ b/MoRI/MoRI/View/OnBoardingView.swift
@@ -22,6 +22,7 @@ struct OnBoardingView: View {
             .padding(.bottom, 22.04)
             Text("좋아하는 가사를 기록하고 간직할\n나만의 음악 카드를 만들어보세요")
                 .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.5)
                 .foregroundColor(.gray01Color)
                 .font(.custom(FontsManager.Pretendard.medium, size: 18))
                 .padding(.bottom, 47.9)
@@ -55,6 +56,10 @@ struct OnBoardingView: View {
             }
         }.frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.gray04Color)
+    }
+    
+    func chooseSize() {
+        
     }
 }
 

--- a/MoRI/MoRI/View/OnBoardingView.swift
+++ b/MoRI/MoRI/View/OnBoardingView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OnBoardingView: View {
     @Binding var isViewed: Bool
+    private let screenWidth = UIScreen.main.bounds.size.width
     
     var body: some View {
         VStack{
@@ -54,8 +55,10 @@ struct OnBoardingView: View {
                         .font(.custom(FontsManager.Pretendard.medium, size: 20))
                 }
             }
-        }.frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.gray04Color)
+        }
+        .scaleEffect(screenWidth/393)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.gray04Color)
     }
     
     func chooseSize() {

--- a/MoRI/MoRI/View/SelectLyricsView.swift
+++ b/MoRI/MoRI/View/SelectLyricsView.swift
@@ -21,6 +21,8 @@ struct SelectLyricsView: View {
     
     @Environment(\.dismiss) private var dismiss
     
+    private let screenWidth = UIScreen.main.bounds.size.width
+    
     var body: some View {
         VStack {
             HStack(spacing: 11){
@@ -50,6 +52,8 @@ struct SelectLyricsView: View {
                 }
                 Spacer()
             }
+            .scaleEffect(screenWidth/393)
+            
             if lyricsViewModel.lyrics.count == 0 {
                 
                 VStack{
@@ -62,6 +66,7 @@ struct SelectLyricsView: View {
                     
                     Spacer(minLength: 250)
                 }
+                .scaleEffect(screenWidth/393)
                 
             }
                 else {
@@ -112,6 +117,7 @@ struct SelectLyricsView: View {
                                 }
                             }
                         }
+//                        .scaleEffect(screenWidth/393)
                         .padding(.leading, 3)
                         
                     }


### PR DESCRIPTION
## 👀 개요
- feat : #124 

## 👍 작업 내용
- 온보딩 뷰 두줄 문자처리

```swift
.minimumScaleFactor(0.5)
```
</br>

- 아이폰 화면 크기에 맞는 뷰 그리기
```swift
 private let screenWidth = UIScreen.main.bounds.size.width

// ... 

.scaleEffect(screenWidth/393)
```
> UIScreen으로 아이폰 화면 너비를 불러오고 scaleEffect를 사용해 비율을 조정했습니다. 
> 393은 아이폰 14 Pro의 너비 입니다 !! 


## 📱 구현한 UI
<img width="1252" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team13-RUN/assets/93391058/3b37a004-2b55-434a-8625-96a647584522">


